### PR TITLE
fix xid varchar(128) in sql scripts

### DIFF
--- a/gorm/scripts/seata_order.sql
+++ b/gorm/scripts/seata_order.sql
@@ -89,7 +89,7 @@ DROP TABLE IF EXISTS `undo_log`;
 CREATE TABLE `undo_log` (
   `id` bigint(20) NOT NULL AUTO_INCREMENT,
   `branch_id` bigint(20) NOT NULL,
-  `xid` varchar(100) NOT NULL,
+  `xid` varchar(128) NOT NULL,
   `context` varchar(128) NOT NULL,
   `rollback_info` longblob NOT NULL,
   `log_status` int(11) NOT NULL,

--- a/gorm/scripts/seata_product.sql
+++ b/gorm/scripts/seata_product.sql
@@ -98,7 +98,7 @@ DROP TABLE IF EXISTS `undo_log`;
 CREATE TABLE `undo_log` (
   `id` bigint(20) NOT NULL AUTO_INCREMENT,
   `branch_id` bigint(20) NOT NULL,
-  `xid` varchar(100) NOT NULL,
+  `xid` varchar(128) NOT NULL,
   `context` varchar(128) CHARACTER SET utf8 COLLATE utf8_general_ci NOT NULL,
   `rollback_info` longblob NOT NULL,
   `log_status` int(11) NOT NULL,

--- a/http/scripts/seata_order.sql
+++ b/http/scripts/seata_order.sql
@@ -89,7 +89,7 @@ DROP TABLE IF EXISTS `undo_log`;
 CREATE TABLE `undo_log` (
   `id` bigint(20) NOT NULL AUTO_INCREMENT,
   `branch_id` bigint(20) NOT NULL,
-  `xid` varchar(100) NOT NULL,
+  `xid` varchar(128) NOT NULL,
   `context` varchar(128) NOT NULL,
   `rollback_info` longblob NOT NULL,
   `log_status` int(11) NOT NULL,

--- a/http/scripts/seata_product.sql
+++ b/http/scripts/seata_product.sql
@@ -98,7 +98,7 @@ DROP TABLE IF EXISTS `undo_log`;
 CREATE TABLE `undo_log` (
   `id` bigint(20) NOT NULL AUTO_INCREMENT,
   `branch_id` bigint(20) NOT NULL,
-  `xid` varchar(100) NOT NULL,
+  `xid` varchar(128) NOT NULL,
   `context` varchar(128) CHARACTER SET utf8 COLLATE utf8_general_ci NOT NULL,
   `rollback_info` longblob NOT NULL,
   `log_status` int(11) NOT NULL,


### PR DESCRIPTION
seata-golang use xid varchar(128) while in sample scripts there is varchar(100) on undo_log table.
